### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,12 +2,9 @@ class ItemsController < ApplicationController
   # 未ログイン時、ログイン画面へ遷移
   before_action :authenticate_user!, except: [:index]
 
-# 商品一覧表示機能で実装予定のためコメントアウト
-=begin
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
-=end
 
   def new
     @item = Item.new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,6 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>    
         <li class='list'>
           <%= link_to items_path(item) do %>
@@ -156,7 +155,7 @@
           <% end %>
         </li>
       <% end %>  
-
+      <%# 商品のデータがない場合は、ダミー商品を表示  %>
       <% if @items.present? == false %>
         <li class='list'>
           <%= link_to '#' do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <ul class='item-lists'>
       <% @items.each do |item| %>    
         <li class='list'>
-          <%= link_to items_path(item) do %>
+          <%#= link_to items_path(item) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,9 +127,6 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-<%
-=begin 商品一覧表示機能で実装予定なのでコメントアウト
-%>    
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>    
         <li class='list'>
@@ -159,9 +156,7 @@
           <% end %>
         </li>
       <% end %>  
-<%
-=end
-%>
+
       <% if @items.present? == false %>
         <li class='list'>
           <%= link_to '#' do %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Item, type: :model do
       it 'ユーザー情報がない場合は登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
 
       it '画像が添付されていないと出品できない' do
@@ -120,7 +120,6 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is not a number')
       end
-
     end
   end
 end


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
トップページに商品一覧を表示させるため

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/aa6afd14587357616963a104b177fa8d

商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/3925abf071f3654cbd73a4cce3547a487